### PR TITLE
2: Add subprocess import for windows compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Package
 on: [push]
 
 jobs:
-  deploy:
+  linux:
     name: "Build and Deploy to Mount Olympus"
     runs-on: ubuntu-latest
     container:
@@ -11,7 +11,7 @@ jobs:
       options: --user root
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: configure conan
         shell: bash
         run: |
@@ -26,4 +26,22 @@ jobs:
         shell: bash
         run: |
           conan upload pyvenv/*@mtolympus/stable -r mtolympus -c
-
+  windows:
+    name: "Build Windows"
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: install conan
+        run: |
+          pip install conan
+      - name: configure conan
+        run: |
+          conan remote add mtolympus https://mtolympus.jfrog.io/artifactory/api/conan/mtolympus-conan
+      - name: create package
+        run: |
+          conan create . mtolympus/stable

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Conan
+build/
+conan.lock
+conanbuildinfo.txt
+conaninfo.txt
+graph_info.json
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,17 +9,19 @@ import json
 import textwrap
 import itertools
 import operator
+import subprocess
 
 
 class PythonVirtualEnvironmentPackage(ConanFile):
     name = "pyvenv"
-    version = "0.1.0"
+    version = "0.1.1"
     url = "https://github.com/samuel-emrys/pyvenv.git"
     homepage = "https://github.com/samuel-emrys/pyvenv.git"
     license = "MIT"
     description = "A python_requires library providing a management class for python virtual environments and a CMake generator to expose executables in those virtual environments as CMake targets"
     topics = ("Python", "Virtual Environment", "CMake", "venv")
     no_copy_source = True
+    package_type = "python-require"
 
 def _args_to_string(args):
     if not args:

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,53 @@
+import os
+import re
+
+from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.tools.build import cross_building
+
+def get_version():
+    # Read the version from the parent conanfile.py
+    # TODO: Remove this when conan 2.0 is usable. This is unnecessary in conan 2.0
+    with open("../conanfile.py", "r") as f:
+        conanfile = f.read()
+    regx = re.compile("\d\.\d\.\d")
+    version = regx.findall(conanfile)[0]
+    return version
+
+class PyvenvTestConan(ConanFile):
+    settings = "os", "build_type", "arch", "compiler"
+    apply_env = False
+    test_type = "explicit"
+
+    # TODO: Remove in 2.0. This restricts the testable user/channel due to 
+    # limitations in 1.x
+    python_requires = f"pyvenv/{get_version()}@mtolympus/stable"
+    build_policy = "missing"
+    _venv = None
+
+    def config_options(self):
+        del self.settings.build_type
+        del self.settings.arch
+        del self.settings.compiler
+
+    def _configure_venv(self):
+        venv = self.python_requires["pyvenv"].module.PythonVirtualEnv
+        if not self._venv:
+            self._venv = venv(self)
+        return self._venv
+
+    def build(self):
+        venv = self._configure_venv()
+        venv.create(folder=os.path.join(self.build_folder))
+        args_to_string = self.python_requires["pyvenv"].module._args_to_string
+        self.run(args_to_string([venv.pip, "install", "sphinx==4.4.0"]))
+
+    def layout(self):
+        basic_layout(self)
+
+    def test(self):
+        bindir = "Scripts" if self.settings.os == "Windows" else "bin"
+        if not cross_building(self):
+            args_to_string = self.python_requires["pyvenv"].module._args_to_string
+            cmd = [os.path.join(self.build_folder, bindir, "sphinx-build"), "--help"]
+            self.run(args_to_string(cmd), env="conanrun")


### PR DESCRIPTION
* Add missing subprocess import for windows compatibility
* Add github actions workflow for windows tests
* Add test_package to test the python-requires. This is limited to testing the mtolympus/stable user and channel due to limitations in 1.x

Closes #2