### PR TITLE
Add ability to relocate the venv

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,9 +1,12 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.tools.env import Environment
+from conan.tools.files import replace_in_file
+from conan.tools.scm import Version
 from pathlib import Path
 from contextlib import contextmanager
 
 import os
+import pathlib
 import sys
 import json
 import textwrap
@@ -14,7 +17,7 @@ import subprocess
 
 class PythonVirtualEnvironmentPackage(ConanFile):
     name = "pyvenv"
-    version = "0.1.1"
+    version = "0.2.0"
     url = "https://github.com/samuel-emrys/pyvenv.git"
     homepage = "https://github.com/samuel-emrys/pyvenv.git"
     license = "MIT"
@@ -23,7 +26,14 @@ class PythonVirtualEnvironmentPackage(ConanFile):
     no_copy_source = True
     package_type = "python-require"
 
-def _args_to_string(args):
+
+def args_to_string(args):
+    """
+    Convert a list of arguments to a command line string in an operating system agnostic way
+
+    :param args: A list of the arguments to provide to the command line
+    :type args: list(str)
+    """
     if not args:
         return ""
     if sys.platform == 'win32':
@@ -31,9 +41,11 @@ def _args_to_string(args):
     else:
         return " ".join("'" + arg.replace("'", r"'\''") + "'" for arg in args)
 
-# mostly like shutil.which, but allows searching for alternate filenames,
-# and never falls back to %PATH% or curdir
 def _which(files, paths, access=os.F_OK | os.X_OK):
+    """
+    Mostly like shutil.which, but allows searching for alternate filenames,
+    and never falls back to %PATH% or curdir
+    """
     if isinstance(files, str):
         files = [files]
     if sys.platform == "win32":
@@ -78,6 +90,9 @@ def _which(files, paths, access=os.F_OK | os.X_OK):
     return None
 
 def _default_python():
+    """
+    Identify the default python interpreter.
+    """
     base_exec_prefix = sys.base_exec_prefix
 
     if hasattr(
@@ -108,24 +123,97 @@ def _default_python():
     else:
         return sys.executable
 
+def _write_activate_this(env_dir, bin_dir, lib_dirs):
+    """
+    Write an activate_this.py to env_dir. This fills a gap where this isn't
+    created by default by the `venv` module. This borrows the implementation from `virtualenv`.
 
+    :param env_dir: The path to the virtual environment directory
+    :type env_dir: str
+    :param bin_dir: The name of the platform specific binary directory. `Scripts` or `bin`.
+    :type bin_dir: str
+    :param lib_dirs: A list of the environment library directories to search when activate_this.py is used
+    :type lib_dirs: list(str)
+    """
+    win_py2 = sys.platform == "win32" and sys.version_info.major == 2
+    decode_path = ("yes" if win_py2 else "")
+    lib_dirs = [os.path.relpath(libdir, os.path.join(env_dir, bin_dir)) for libdir in lib_dirs]
+    lib_dirs = os.pathsep.join(lib_dirs)
+    contents = textwrap.dedent(f"""\
+        import os
+        import site
+        import sys
 
+        try:
+            abs_file = os.path.abspath(__file__)
+        except NameError:
+            raise AssertionError("You must use exec(open(this_file).read(), {{'__file__': this_file}}))")
+
+        bin_dir = os.path.dirname(abs_file)
+        base = bin_dir[: -len("{bin_dir}") - 1]  # strip away the bin part from the __file__, plus the path separator
+
+        # prepend bin to PATH (this file is inside the bin directory)
+        os.environ["PATH"] = os.pathsep.join([bin_dir] + os.environ.get("PATH", "").split(os.pathsep))
+        os.environ["VIRTUAL_ENV"] = base  # virtual env is right above bin directory
+
+        # add the virtual environments libraries to the host python import mechanism
+        prev_length = len(sys.path)
+        for lib in "{lib_dirs}".split(os.pathsep):
+            path = os.path.realpath(os.path.join(bin_dir, lib))
+            site.addsitedir(path.decode("utf-8") if "{decode_path}" else path)
+        sys.path[:] = sys.path[prev_length:] + sys.path[0:prev_length]
+
+        sys.real_prefix = sys.prefix
+        sys.prefix = base
+    """)
+
+    with open(os.path.join(env_dir, bin_dir, "activate_this.py"), "w") as f:
+        f.write(contents)
 
 # build helper for making and managing python virtual environments
 class PythonVirtualEnv:
-    def __init__(self, conanfile, python=_default_python(), env_folder=None):
-        self._conanfile = conanfile
-        self.base_python = python
-        self.env_folder = env_folder
+    """
+    A build helper for creating and managing python virtual environments
+    """
+    def __init__(self, conanfile, interpreter=_default_python(), env_folder=None):
+        """
+        Create a PythonVirtualEnv object
 
-    # symlink logic borrowed from python -m venv
-    # See venv.main() in /Lib/venv/__init__
-    def create(self, folder, *, clear=True, symlinks=(os.name != "nt"), with_pip=True):
+        :param conanfile: A reference to the conanfile invoking the PythonVirtualEnv object
+        :type package: ConanFile
+        :param interpreter: A path to the interpreter to use for the virtual environment. Defaults
+        to the first python discovered on the PATH.
+        :type package: str
+        :param env_folder: The directory for the python virtual environment to manage or create. Defaults to `None`.
+        :type package: str
+        """
+        self._conanfile = conanfile
+        self.base_python = interpreter
+        self.env_folder = env_folder
+        self._debug = self._conanfile.output.debug if (Version(conan_version).major >= 2) else self._conanfile.output.info
+
+    def create(self, folder, *, clear=True, symlinks=(os.name != "nt"), with_pip=True, requirements=[]):
+        """
+        Create a virtual environment
+        symlink logic borrowed from python -m venv
+        See venv.main() in /Lib/venv/__init__
+
+        :param folder: The directory in which to create the virtual environment
+        :type folder: str
+        :param clear: Delete the contents of the environment directory if it already exists, before environment creation
+        :type clear: str
+        :param symlinks: Try to use symlinks rather than copies, when symlinks are not the default for the platform.
+        Defaults to `False for windows, and `True` otherwise.
+        :type symlinks: str
+        :param with_pip: Install pip in the virtual environment. Defaults to `True`.
+        :type with_pip: str
+        :param requirements: A list of requirements to install in the virtual environment
+        :type requirements: list(str)
+        """
         self.env_folder = folder
 
         self._conanfile.output.info(
-            "creating venv at %s based on %s"
-            % (self.env_folder, self.base_python or "<conanfile>")
+            f"creating venv at {self.env_folder} based on {self.base_python or '<conanfile>'}"
         )
 
         if self.base_python:
@@ -142,7 +230,7 @@ class PythonVirtualEnv:
             envvars = env.vars(self._conanfile, scope="build")
             envvars.save_script("build_python")
             self._conanfile.run(
-                _args_to_string(
+                args_to_string(
                     [self.base_python, "-mvenv", *venv_options, self.env_folder]
                 ),
                 env="conanbuild"
@@ -155,13 +243,27 @@ class PythonVirtualEnv:
             builder = venv.EnvBuilder(clear=clear, symlinks=symlinks, with_pip=with_pip)
             builder.create(self.env_folder)
 
+        if requirements:
+            self._conanfile.run(
+                args_to_string([self.pip, "install", *requirements]),
+                env="conanbuild"
+            )
+
+        _write_activate_this(env_dir=self.env_folder, bin_dir=self.bin_dir, lib_dirs=self.libpath)
+        self.make_relocatable(env_folder=self.env_folder)
+
     def entry_points(self, package=None):
+        """
+        Retrieve the entry points available for a package
+        :param package: The package to return entry points for. Default is `None`
+        :type package: str
+        """
         import importlib.metadata  # Python 3.8 or greater
 
         entry_points = itertools.chain.from_iterable(
             dist.entry_points
             for dist in importlib.metadata.distributions(
-                name=package, path=self.lib_paths
+                name=package, path=self.libpath
             )
         )
 
@@ -174,6 +276,16 @@ class PythonVirtualEnv:
         }
 
     def setup_entry_points(self, package, folder, silent=False):
+        """
+        Add entry points for a package to the virtual environment. In most cases this shouldn't be required.
+
+        :param package: The package to add entry points for
+        :type package: str
+        :param folder: The directory in which to configure the entry points.
+        :type folder: str
+        :param silent: Suppress log output. Default is `False`
+        :type silent: bool
+        """
         # create target folder
         try:
             os.makedirs(folder)
@@ -188,8 +300,8 @@ class PythonVirtualEnv:
                 path = self.which(name, required=True)
             except FileNotFoundError as e:
                 # avoid FileNotFound if the no launcher script for this name was found, or
-                self._conanfile.output.warn(
-                    "pyvenv.setup_entry_points: FileNotFoundError: %s" % e
+                self._conanfile.output.warning(
+                    f"pyvenv.setup_entry_points: FileNotFoundError: {e}"
                 )
                 return
 
@@ -226,22 +338,59 @@ class PythonVirtualEnv:
             self._conanfile.output.info(f"Adding entry point for {name}")
             copy_executable(name, folder, type="gui")
 
+
     @property
-    def bin_paths(self):
+    def _version(self):
+        return "{}.{}".format(*sys.version_info)
+
+    @property
+    def _python_version(self):
+        return f"python{self._version}"
+
+    @property
+    def _is_pypy(self):
+        return hasattr(sys, "pypy_version_info")
+
+    @property
+    def _is_win(self):
+        return sys.platform == "win32"
+
+    @property
+    def _abi_flags(self):
+        return getattr(sys, "abiflags", "")
+
+    @property
+    def _no_shebang_scripts(self):
+        return [
+            "python",
+            self._python_version,
+            "activate",
+            "activate.sh",
+            "activate.bat",
+            "activate_this.py",
+            "activate.fish",
+            "activate.csh",
+            "activate.xsh",
+            "activate.nu",
+            "Activate.ps1",
+        ]
+
+    @property
+    def bin_dir(self):
+        return "Scripts" if self._is_win else "bin"
+
+    @property
+    def binpath(self):
         # this should be the same logic as as
         # context.bin_name = ... in venv.ensure_directories
-        if sys.platform == "win32":
-            binname = "Scripts"
-        else:
-            binname = "bin"
-        bindirs = [binname]
+        bindirs = [self.bin_dir]
         return [os.path.join(self.env_folder, x) for x in bindirs]
 
     @property
-    def lib_paths(self):
+    def libpath(self):
         # this should be the same logic as as
         # libpath = ... in venv.ensure_directories
-        if sys.platform == "win32":
+        if self._is_win:
             libpath = os.path.join(self.env_folder, "Lib", "site-packages")
         else:
             libpath = os.path.join(
@@ -254,50 +403,526 @@ class PythonVirtualEnv:
 
     # return the path to a command within the venv, None if only found outside
     def which(self, command, required=False, **kwargs):
-        found = _which(command, self.bin_paths, **kwargs)
+        found = _which(command, self.binpath, **kwargs)
         if found:
             return found
         elif required:
             raise FileNotFoundError(
-                "command %s not in venv bin_paths %s"
-                % (command, os.pathsep.join(self.bin_paths))
+                f"command {command} not in venv binpath {os.pathsep.join(self.binpath)}"
             )
         else:
             return None
 
-    # convenience wrappers for python/pip since they are so commonly needed
     @property
     def python(self):
+        """
+        Convenience wrapper for python. Can be used to avoid activating the environment when
+        installing dependencies, i.e.:
+        self.run(args_to_string([venv.python, "-mpip", "install", "sphinx"])
+        """
         return self.which("python", required=True)
 
     @property
     def pip(self):
+        """
+        Convenience wrapper for pip. Ensure that this is used in conjunction with activate
+        to ensure that the python interpreter inside the venv is used, i.e.
+        with venv.activate():
+            self.run(args_to_string([venv.pip, "install", "sphinx"])
+        """
         return self.which("pip", required=True)
 
-    # environment variables like the usual venv `activate` script, i.e.
-    # with tools.environment_append(venv.env):
-    #     ...
     @property
     def env(self):
+        """
+        environment variables like the usual venv `activate` script, i.e.
+        with tools.environment_append(venv.env):
+            ...
+        """
         return {
             "__PYVENV_LAUNCHER__": None,  # this might already be set if conan was launched through a venv
             "PYTHONHOME": None,
             "VIRTUAL_ENV": self.env_folder,
-            "PATH": self.bin_paths,
+            "PATH": self.binpath,
         }
 
-    # Setup environment and add site_packages of this this venv to sys.path
-    # (importing from the venv only works if it contains python modules compatible
-    #  with conan's python interrpreter as well as the venv one
-    # But they're generally the same per _default_python(), so this will let you try
-    # with venv.activate():
-    #     ...
     @contextmanager
     def activate(self):
+        """
+        Setup environment and add site_packages of this this venv to sys.path
+        (importing from the venv only works if it contains python modules compatible
+         with conan's python interrpreter as well as the venv one
+        But they're generally the same per _default_python(), so this will let you try
+        with venv.activate():
+            ...
+        """
         old_path = sys.path[:]
-        sys.path.extend(self.lib_paths)
-        with tools.environment_append(self.env):
+        sys.path.extend(self.libpath)
+        env = Environment()
+        for k, v in self.env.items():
+            env.define(k, v)
+        envvars = env.vars(self._conanfile, scope="build")
+        with envvars.apply():
             yield
         sys.path = old_path
 
+    def make_relocatable(self, env_folder):
+        """
+        Makes the already-existing environment use relative paths, and takes out
+        the #!-based environment selection in scripts.
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1890-L1903
+        MIT License
 
+        :param env_folder: The path to the virtual environment to make relocatable
+        :type env_folder: str
+        """
+        home_dir, lib_dir, inc_dir, bin_dir = self._path_locations(env_folder)
+        activate_this = os.path.join(bin_dir, "activate_this.py")
+        if not os.path.exists(activate_this):
+            self._conanfile.output.error(
+                f"The environment doesn't have a file {activate_this} -- please re-run virtualenv " "on this environment to update it"
+            )
+        self._fixup_scripts(bin_dir)
+        self._fixup_pth_and_egg_link(home_dir)
+        self._patch_activate_scripts(bin_dir)
+
+    def _path_locations(self, home_dir):
+        """
+        Return the path locations for the environment (where libraries are,
+        where scripts go, etc)
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1199-L1241
+        MIT License
+        :param home_dir: The base path to the virtual environment
+        :type home_dir: str
+        """
+        home_dir = os.path.abspath(home_dir)
+        lib_dir, inc_dir, bin_dir = None, None, None
+        # XXX: We'd use distutils.sysconfig.get_python_inc/lib but its
+        # prefix arg is broken: http://bugs.python.org/issue3386
+        if self._is_win:
+            # Windows has lots of problems with executables with spaces in
+            # the name; this function will remove them (using the ~1
+            # format):
+            mkdir(home_dir)
+            if " " in home_dir:
+                import ctypes
+
+                get_short_path_name = ctypes.windll.kernel32.GetShortPathNameW
+                size = max(len(home_dir) + 1, 256)
+                buf = ctypes.create_unicode_buffer(size)
+                try:
+                    # noinspection PyUnresolvedReferences
+                    u = unicode
+                except NameError:
+                    u = str
+                ret = get_short_path_name(u(home_dir), buf, size)
+                if not ret:
+                    print('Error: the path "{}" has a space in it'.format(home_dir))
+                    print("We could not determine the short pathname for it.")
+                    print("Exiting.")
+                    sys.exit(3)
+                home_dir = str(buf.value)
+            lib_dir = os.path.join(home_dir, "Lib")
+            inc_dir = os.path.join(home_dir, "Include")
+            bin_dir = os.path.join(home_dir, "Scripts")
+        if self._is_pypy:
+            lib_dir = home_dir
+            inc_dir = os.path.join(home_dir, "include")
+            bin_dir = os.path.join(home_dir, "bin")
+        elif not self._is_win:
+            lib_dir = os.path.join(home_dir, "lib", self._python_version)
+            inc_dir = os.path.join(home_dir, "include", self._python_version + self._abi_flags)
+            bin_dir = os.path.join(home_dir, "bin")
+        return home_dir, lib_dir, inc_dir, bin_dir
+
+    def _fixup_scripts(self, bin_dir):
+        """
+        Replaces the shebang (or windows equivalent) with a relative python path and invocation of activate_this.py
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1919-L1966
+        MIT License
+        :param bin_dir: The path to the virtual environment binary directory
+        :type bin_dir: str
+        """
+        if self._is_win:
+            new_shebang_args = ("{} /c".format(os.path.normcase(os.environ.get("COMSPEC", "cmd.exe"))), "", ".exe")
+        else:
+            new_shebang_args = ("/usr/bin/env", self._version, "")
+
+        # This is what we expect at the top of scripts:
+        shebang = "#!{}".format(
+            os.path.normcase(os.path.join(os.path.abspath(bin_dir), "python{}".format(new_shebang_args[2])))
+        )
+        # This is what we'll put:
+        new_shebang = "#!{} python{}{}".format(*new_shebang_args)
+
+        for filename in os.listdir(bin_dir):
+            filename = os.path.join(bin_dir, filename)
+            if not os.path.isfile(filename):
+                # ignore child directories, e.g. .svn ones.
+                continue
+            with open(filename, "rb") as f:
+                try:
+                    lines = f.read().decode("utf-8").splitlines()
+                except UnicodeDecodeError:
+                    # This is probably a binary program instead
+                    # of a script, so just ignore it.
+                    continue
+            if not lines:
+                self._conanfile.output.warning(f"Script {filename} is an empty file")
+                continue
+
+            old_shebang = lines[0].strip()
+            old_shebang = old_shebang[0:2] + os.path.normcase(old_shebang[2:])
+
+            if not old_shebang.startswith(shebang):
+                if os.path.basename(filename) in self._no_shebang_scripts:
+                    # These scripts will be patched by in a separate stage by self._patch_activate_scripts
+                    continue
+                elif lines[0].strip() == new_shebang:
+                    self._debug(f"Script {filename} has already been made relative")
+                else:
+                    self._conanfile.output.warning(
+                        f"Script {filename} cannot be made relative (it's not a normal script that starts with {shebang})"
+                    )
+                continue
+            self._conanfile.output.info(f"Making script {filename} relative")
+            script = self._relative_script([new_shebang] + lines[1:])
+            with open(filename, "wb") as f:
+                f.write("\n".join(script).encode("utf-8"))
+
+
+
+    def _relative_script(self, lines):
+        """
+        Return a script that'll work in a relocatable environment.
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1969-L1987
+        MIT License
+
+        :param lines: Raw contents of the script to patch
+        :type lines: list(str)
+        """
+        activate = (
+            "import os; "
+            "activate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'activate_this.py'); "
+            "exec(compile(open(activate_this).read(), activate_this, 'exec'), { '__file__': activate_this}); "
+            "del os, activate_this"
+        )
+        # Find the last future statement in the script. If we insert the activation
+        # line before a future statement, Python will raise a SyntaxError.
+        activate_at = None
+        for idx, line in reversed(list(enumerate(lines))):
+            if line.split()[:3] == ["from", "__future__", "import"]:
+                activate_at = idx + 1
+                break
+        if activate_at is None:
+            # Activate after the shebang.
+            activate_at = 1
+        return lines[:activate_at] + ["", activate, ""] + lines[activate_at:]
+
+
+
+    def _fixup_pth_and_egg_link(self, home_dir, sys_path=None):
+        """
+        Makes .pth and .egg-link files use relative paths
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1990-L2015
+        MIT License
+
+        :param home_dir: The base path to the virtual environment
+        :type home_dir: str
+        :param sys_path: The system path to use
+        :type sys_path: str
+        """
+        home_dir = os.path.normcase(os.path.abspath(home_dir))
+        if sys_path is None:
+            sys_path = sys.path
+        for a_path in sys_path:
+            if not a_path:
+                a_path = "."
+            if not os.path.isdir(a_path):
+                continue
+            a_path = os.path.normcase(os.path.abspath(a_path))
+            if not a_path.startswith(home_dir):
+                self._debug(f"Skipping system (non-environment) directory {a_path}")
+                continue
+            for filename in os.listdir(a_path):
+                filename = os.path.join(a_path, filename)
+                if filename.endswith(".pth"):
+                    if not os.access(filename, os.W_OK):
+                        self._conanfile.output.warning(f"Cannot write .pth file {filename}, skipping")
+                    else:
+                        self._fixup_pth_file(filename)
+                if filename.endswith(".egg-link"):
+                    if not os.access(filename, os.W_OK):
+                        self._conanfile.output.warning(f"Cannot write .egg-link file {filename}, skipping")
+                    else:
+                        self._fixup_egg_link(filename)
+
+
+    def _fixup_pth_file(self, filename):
+        """
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L2018-L2036
+        MIT License
+
+        :param filename: Path to the file to fix
+        :type filename: str
+        """
+        lines = []
+        with open(filename) as f:
+            prev_lines = f.readlines()
+        for line in prev_lines:
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("import ") or os.path.abspath(line) != line:
+                lines.append(line)
+            else:
+                new_value = self._make_relative_path(filename, line)
+                if line != new_value:
+                    self._debug("Rewriting path {} as {} (in {})".format(line, new_value, filename))
+                lines.append(new_value)
+        if lines == prev_lines:
+            self._conanfile.output.info(f"No changes to .pth file {filename}")
+            return
+        self._conanfile.output.info(f"Making paths in .pth file {filename} relative")
+        with open(filename, "w") as f:
+            f.write("\n".join(lines) + "\n")
+
+
+    def _fixup_egg_link(self, filename):
+        """
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L2039-L2048
+        MIT License
+
+        :param filename: Path to the file to fix
+        :type filename: str
+        """
+        with open(filename) as f:
+            link = f.readline().strip()
+        if os.path.abspath(link) != link:
+            self._debug(f"Link in {filename} already relative")
+            return
+        new_link = self._make_relative_path(filename, link)
+        self._conanfile.output.info("Rewriting link {} in {} as {}".format(link, filename, new_link))
+        with open(filename, "w") as f:
+            f.write(new_link)
+
+
+    def _make_relative_path(self, source, dest, dest_is_directory=True):
+        """
+        Make a filename relative, where the filename is dest, and it is
+        being referred to from the filename source.
+        Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L2051-L2084
+        MIT License
+            >>> make_relative_path('/usr/share/something/a-file.pth',
+            ...                    '/usr/share/another-place/src/Directory')
+            '../another-place/src/Directory'
+            >>> make_relative_path('/usr/share/something/a-file.pth',
+            ...                    '/home/user/src/Directory')
+            '../../../home/user/src/Directory'
+            >>> make_relative_path('/usr/share/a-file.pth', '/usr/share/')
+            './'
+
+        :param source: The path from which the filename will be referred to
+        :type source: str
+        :param dest: The filename to be referred to from `source`
+        :type dest: str
+        :param dest_is_directory: Flag indicating whether `dest` is a directory. Defaults to `True`
+        :type dest: bool
+        """
+        source = os.path.dirname(source)
+        if not dest_is_directory:
+            dest_filename = os.path.basename(dest)
+            dest = os.path.dirname(dest)
+        else:
+            dest_filename = None
+        dest = os.path.normpath(os.path.abspath(dest))
+        source = os.path.normpath(os.path.abspath(source))
+        dest_parts = dest.strip(os.path.sep).split(os.path.sep)
+        source_parts = source.strip(os.path.sep).split(os.path.sep)
+        while dest_parts and source_parts and dest_parts[0] == source_parts[0]:
+            dest_parts.pop(0)
+            source_parts.pop(0)
+        full_parts = [".."] * len(source_parts) + dest_parts
+        if not dest_is_directory and dest_filename is not None:
+            full_parts.append(dest_filename)
+        if not full_parts:
+            # Special case for the current directory (otherwise it'd be '')
+            return "./"
+        return os.path.sep.join(full_parts)
+
+    def _patch_activate_scripts(self, bin_dir):
+        """
+        Patch the virtualenvs activation scripts such that they discover the virtualenv path dynamically
+        rather than hardcoding it to make them robust to relocation.
+
+        :param bin_dir: The path to the folder in which the activation scripts to be patched lie.
+        :type bin_dir: str
+        """
+
+        scripts = {
+            pathlib.Path(bin_dir, "activate"): self._patch_activate,
+            pathlib.Path(bin_dir, "activate.sh"): self._patch_activate,
+            pathlib.Path(bin_dir, "activate.bat"): self._patch_activate_bat,
+            pathlib.Path(bin_dir, "activate.fish"): self._patch_activate_fish,
+            pathlib.Path(bin_dir, "activate.csh"): self._patch_activate_csh,
+            #pathlib.Path(bin_dir, "activate.xsh"): self._patch_activate_xsh,
+            #pathlib.Path(bin_dir, "activate.nu"): self._patch_activate_nu,
+        }
+
+        for script, patch in scripts.items():
+            if script.is_file():
+                self._conanfile.output.info(f"Making {script} relocatable.")
+                patch(script)
+
+    def _patch_activate(self, activate):
+        """
+        Patch a bash, sh, ksh, zsh or dash script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+        Derived from https://github.com/jpenney/virtualenv/blob/611c4b4ff33540d84fb876daf7fddf460adfee20/virtualenv_embedded/activate.sh
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+
+        with open(activate) as f:
+            if "ACTIVATE_PATH_FALLBACK" in f.read():
+                self._debug(f"{activate} has already been made relocatable. Continuing.")
+                return
+
+        replace_in_file(
+            self._conanfile,
+            file_path=activate, 
+            search='deactivate () {',
+            replace=textwrap.dedent('''\
+                ACTIVATE_PATH_FALLBACK="$_"
+                deactivate () {
+                '''
+            ),
+        )
+
+        replace_in_file(
+            self._conanfile,
+            file_path=activate, 
+            search=f'VIRTUAL_ENV="{os.path.abspath(self.env_folder)}"',
+            replace=textwrap.dedent(f'''\
+                # Attempt to determine VIRTUAL_ENV in relocatable way
+                if [ ! -z "${{BASH_SOURCE:-}}" ]; then
+                    # bash
+                    ACTIVATE_PATH="${{BASH_SOURCE}}"
+                elif [ ! -z "${{DASH_SOURCE:-}}" ]; then
+                    # dash
+                    ACTIVATE_PATH="${{DASH_SOURCE}}"
+                elif [ ! -z "${{ZSH_VERSION:-}}" ]; then
+                    # zsh
+                    ACTIVATE_PATH="$0"
+                elif [ ! -z "${{KSH_VERSION:-}}" ] || [ ! -z "${{.sh.version:}}" ]; then
+                    # ksh - we have to use history, and unescape spaces before quoting
+                    ACTIVATE_PATH="$(history -r -l -n | head -1 | sed -e 's/^[\t ]*\(\.\|source\) *//;s/\\ / /g')"
+                elif [ "$(basename "$ACTIVATE_PATH_FALLBACK")" == "activate.sh" ]; then
+                    ACTIVATE_PATH="${{ACTIVATE_PATH_FALLBACK}}"
+                else
+                    ACTIVATE_PATH=""
+                fi
+
+                # Default to non-relocatable path
+                VIRTUAL_ENV="{os.path.abspath(self.env_folder)}"
+                if [ ! -z "${{ACTIVATE_PATH:-}}" ]; then
+                    VIRTUAL_ENV="$(cd "$(dirname "${{ACTIVATE_PATH}}")/.."; pwd)"
+                fi
+                unset ACTIVATE_PATH
+                unset ACTIVATE_PATH_FALLBACK
+                '''
+            ),
+        )
+
+
+    def _patch_activate_bat(self, activate):
+        """
+        Patch a bat script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+        Derived from https://github.com/jpenney/virtualenv/blob/611c4b4ff33540d84fb876daf7fddf460adfee20/virtualenv_embedded/activate.bat
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+        with open(activate) as f:
+            if "~dp0" in f.read():
+                self._debug(f"{activate} has already been made relocatable. Continuing.")
+                return
+
+        replace_in_file(
+            self._conanfile,
+            file_path=activate, 
+            search=f'set "VIRTUAL_ENV={os.path.abspath(self.env_folder)}"',
+            replace=textwrap.dedent('''\
+                pushd %~dp0..
+                set "VIRTUAL_ENV=%CD%"
+                popd
+                '''
+            ),
+        )
+
+    def _patch_activate_fish(self, activate):
+        """
+        Patch a fish script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+        Derived from https://github.com/jpenney/virtualenv/blob/611c4b4ff33540d84fb876daf7fddf460adfee20/virtualenv_embedded/activate.fish
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+        with open(activate) as f:
+            if "dirname" in f.read():
+                self._debug(f"{activate} has already been made relocatable. Continuing.")
+                return
+
+        replace_in_file(
+            self._conanfile,
+            file_path=activate, 
+            search=f'set -gx VIRTUAL_ENV "{os.path.abspath(self.env_folder)}"',
+            replace='set -gx VIRTUAL_ENV (cd (dirname (status -f)); cd ..; pwd)',
+        )
+
+    def _patch_activate_csh(self, activate):
+        """
+        Patch a csh script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+        with open(activate) as f:
+            if "dirname" in f.read():
+                self._debug(f"{activate} has already been made relocatable. Continuing.")
+                return
+
+        replace_in_file(
+            self._conanfile,
+            file_path=activate, 
+            search=f'setenv VIRTUAL_ENV "{os.path.abspath(self.env_folder)}"',
+            replace=textwrap.dedent('''\
+                set scriptpath=`find /proc/$$/fd -type l -lname '*activate.csh' -printf '%l' | xargs dirname`
+                setenv VIRTUAL_ENV `cd $scriptpath/.. && pwd`
+                '''
+            ),
+        )
+
+    def _patch_activate_xsh(self, activate):
+        """
+        Patch a xonsh script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+        self._conanfile.output.error(f"No patch algorithm for 'xonsh' is available to patch {activate}. Contributions are welcome. Unable to make relocatable.")
+        return
+
+    def _patch_activate_nu(self, activate):
+        """
+        Patch a nushell script such that it discovers the virtualenv path dynamically
+        rather than hardcoding it to make it robust to relocation.
+
+        :param activate: Path to the script to patch
+        :type activate: str
+        """
+        self._conanfile.output.error(f"No patch algorithm for 'nu' is available to patch {activate}. Contributions are welcome. Unable to make relocatable.")
+        return

--- a/conanfile.py
+++ b/conanfile.py
@@ -470,6 +470,21 @@ class PythonVirtualEnv:
         """
         Makes the already-existing environment use relative paths, and takes out
         the #!-based environment selection in scripts.
+
+        This functionality does not make a virtual environment relocatable to any
+        environment other than the one in which it was created in. This is only suitable
+        for moving a venv directory to another directory in the same environment, such
+        as would be achieved with `mv venv venv2`.
+
+        This functionality is _NOT_ suitable for transplanting a venv for usage in a
+        deployment environment, where it is on a different physical machine, with a
+        different python interpreter, or different underlying library requirements, such
+        as GLIBC. It is only suitable for usage within the same environment in which it
+        was built.
+
+        In a conan context, the resulting virtualenv should not be uploaded to a server.
+        The `build_policy="missing"` and `upload_policy="skip"` attributes should be set.
+
         Derived from https://github.com/pypa/virtualenv/blob/fb6e546cc1dfd0d363dc4d769486805d2d8f04bc/virtualenv.py#L1890-L1903
         MIT License
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -24,10 +24,17 @@ class PyvenvTestConan(ConanFile):
         return self._venv
 
     def build(self):
+        args_to_string = self.python_requires["pyvenv"].module.args_to_string
         venv = self._configure_venv()
-        venv.create(folder=os.path.join(self.build_folder))
-        args_to_string = self.python_requires["pyvenv"].module._args_to_string
-        self.run(args_to_string([venv.pip, "install", "sphinx==4.4.0"]))
+        # Any of the three following techniques to install are supported
+        venv.create(folder=os.path.join(self.build_folder), requirements=["sphinx==4.4.0"])
+        self.run(args_to_string([venv.python, "-mpip", "install", "sphinx-rtd-theme"]), env="conanbuild")
+        with venv.activate():
+            # Invoking venv.pip _must_ be in an activated virtualenv
+            # If you don't do this, the system interpreter will be used and the package won't be patchable
+            self.run(args_to_string([venv.pip, "install", "sphinx-multiversion"]), env="conanbuild")
+        # make_relocatable is only necessary for packages installed outside of `venv.create`
+        venv.make_relocatable(env_folder=self.build_folder)
 
     def layout(self):
         basic_layout(self)
@@ -35,6 +42,6 @@ class PyvenvTestConan(ConanFile):
     def test(self):
         bindir = "Scripts" if self.settings.os == "Windows" else "bin"
         if not cross_building(self):
-            args_to_string = self.python_requires["pyvenv"].module._args_to_string
+            args_to_string = self.python_requires["pyvenv"].module.args_to_string
             cmd = [os.path.join(self.build_folder, bindir, "sphinx-build"), "--help"]
             self.run(args_to_string(cmd), env="conanrun")


### PR DESCRIPTION
* Add functionality to patch the required application/library scripts to use the python interpreter in the virtualenv root rather than a hardcoded path
* Patch activation scripts such that they self discover their location rather than hardcoding the absolute path of the virtualenv
* Document added functions with docstrings
* Revise interface of some functions for clarity
    
Closes #6