### PR TITLE
Fix relocatability for windows environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ conanbuildinfo.txt
 conaninfo.txt
 graph_info.json
 
+build-relocated/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create a new python virtual environment:
 
 ```python
 class PythonVirtualEnvironment(ConanFile):
-    python_requires = "pyvenv/[>=0.2.0]@mtolympus/stable"
+    python_requires = "pyvenv/[>=0.2.1]@mtolympus/stable"
 
     def package(self):
         requirements = ["sphinx==4.4.0", "sphinx_rtd_theme=0.5.3", "matplotlib==3.5.0"]
@@ -43,7 +43,7 @@ Manage an existing python virtual environment:
 from pathlib import Path
 
 class PythonVirtualEnvironment(ConanFile):
-    python_requires = "pyvenv/[>=0.2.0]@mtolympus/stable"
+    python_requires = "pyvenv/[>=0.2.1]@mtolympus/stable"
 
     @property
     def binpath(self):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import pathlib
 
 from conan import ConanFile
 from conan.tools.layout import basic_layout
@@ -23,25 +25,53 @@ class PyvenvTestConan(ConanFile):
             self._venv = venv(self)
         return self._venv
 
+    @property
+    def _bindir(self):
+        return "Scripts" if self.settings.os == "Windows" else "bin"
+
     def build(self):
         args_to_string = self.python_requires["pyvenv"].module.args_to_string
         venv = self._configure_venv()
         # Any of the three following techniques to install are supported
-        venv.create(folder=os.path.join(self.build_folder), requirements=["sphinx==4.4.0"])
-        self.run(args_to_string([venv.python, "-mpip", "install", "sphinx-rtd-theme"]), env="conanbuild")
-        with venv.activate():
-            # Invoking venv.pip _must_ be in an activated virtualenv
-            # If you don't do this, the system interpreter will be used and the package won't be patchable
-            self.run(args_to_string([venv.pip, "install", "sphinx-multiversion"]), env="conanbuild")
+        requirements=["sphinx==4.4.0"]
+        venv.create(folder=os.path.join(self.build_folder), requirements=requirements)
+        #self.run(args_to_string([venv.python, "-mpip", "install", "sphinx-rtd-theme"]), env="conanbuild")
+        #with venv.activate():
+        #    # Invoking venv.pip _must_ be in an activated virtualenv
+        #    # If you don't do this, the system interpreter will be used and the package won't be patchable
+        #    self.run(args_to_string([venv.pip, "install", "sphinx-multiversion"]), env="conanbuild")
         # make_relocatable is only necessary for packages installed outside of `venv.create`
+        for requirement in requirements:
+            package = requirement.split("==")[0]
+            venv.setup_entry_points(str(package), os.path.join(self.build_folder, self._bindir))
+
         venv.make_relocatable(env_folder=self.build_folder)
+
 
     def layout(self):
         basic_layout(self)
 
+    def _rm_directory_contents(self, directory):
+        directory = pathlib.Path(directory)
+        for item in directory.glob("*/*/*"):
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                os.remove(item)
+
     def test(self):
-        bindir = "Scripts" if self.settings.os == "Windows" else "bin"
         if not cross_building(self):
             args_to_string = self.python_requires["pyvenv"].module.args_to_string
-            cmd = [os.path.join(self.build_folder, bindir, "sphinx-build"), "--help"]
+            cmd = [os.path.join(self.build_folder, self._bindir, "sphinx-build"), "--help"]
+            self.run(args_to_string(cmd), env="conanrun")
+
+            self.output.info("Testing ability to relocate virtualenv")
+            new_build_folder = f"{self.build_folder}-relocated"
+            # Can't move self.build_folder because this process has it open, so
+            # copy instead and remove all files inside
+            shutil.copytree(self.build_folder, new_build_folder,
+                             dirs_exist_ok=True)
+            #shutil.rmtree(os.path.join(self.build_folder, self._bindir))
+            self._rm_directory_contents(self.build_folder)
+            cmd = [os.path.join(new_build_folder, self._bindir, "sphinx-build"), "--help"]
             self.run(args_to_string(cmd), env="conanrun")


### PR DESCRIPTION
Fixes a problem in virtualenv relocatability on windows where simple string substitution on executables would cause crc32 errors as zip file metadata wasn't appropriately updated. This is resolved by reading the contents of the zip inside each .exe, modifying the string, and re-constructing the executable including the python launcher wrapper.